### PR TITLE
ci: add GitHub Actions workflow for check, test, fmt, and clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Check, Test, Format, Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⬇️ Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🦀 Install Rust (stable)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: clippy, rustfmt
+
+      - name: 🔍 cargo fmt --check
+        run: cargo fmt --check
+
+      - name: 🧪 cargo check
+        run: cargo check
+
+      - name: ✅ cargo test
+        run: cargo test
+
+      - name: 🧼 cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/README.md
+++ b/README.md
@@ -39,12 +39,6 @@ RUST_LOG=debug cargo run --bin fire-control
 
 It listens on port `8124` and logs events via `tracing`.
 
-Use `RUST_LOG=debug` to see full logs:
-
-```bash
-RUST_LOG=debug cargo run --bin fire-control
-```
-
 ---
 
 ## 🧪 Test Driver

--- a/src/command.rs
+++ b/src/command.rs
@@ -35,7 +35,8 @@ mod tests {
     #[test]
     fn parses_valid_fire_commands() -> Result<()> {
         ensure!(FireCommand::from_str("10")? == FireCommand::Fire(10.0));
-        ensure!(FireCommand::from_str("3.14")? == FireCommand::Fire(3.14));
+
+        ensure!(FireCommand::from_str("13.1280")? == FireCommand::Fire(13.128));
         ensure!(FireCommand::from_str("  2.5 ")? == FireCommand::Fire(2.5));
         Ok(())
     }


### PR DESCRIPTION
- Runs on push and PR to main using ubuntu-latest
- Ensures formatting with `cargo fmt --check`
- Enforces linting with `cargo clippy --all-targets --all-features -- -D warnings`

Closes #7 